### PR TITLE
Add F1 The Movie credit across site

### DIFF
--- a/COMPLETE_SEO_VERIFICATION_2025.md
+++ b/COMPLETE_SEO_VERIFICATION_2025.md
@@ -75,6 +75,7 @@ Your SEO implementation is **FLAWLESS** for an actor's portfolio in 2025. Google
 ### **Career Highlights**
 - **ESPN+ "Fuse"** - Sports comedy series (2023)
 - **"Continue to Win"** - Independent pilot directed by Lester Speight (2025)
+- **"F1 The Movie"** - Feature film cardistry consultant (2025)
 - **Digital Content Creator** with massive social media reach
 - **Theater Experience** - Erie Community Theater lead roles
 

--- a/FINAL_SEO_ANALYSIS_2025.md
+++ b/FINAL_SEO_ANALYSIS_2025.md
@@ -76,6 +76,7 @@ Your SEO implementation is **OUTSTANDING** for an actor's portfolio. Here's why 
 - **ESPN+** series "Fuse" (Executive Producer/Talent)
 - **1M+ TikTok** followers (@usamedical)
 - **Independent film** "Continue to Win" (Lead Antagonist)
+- **Feature film** "F1 The Movie" (Cardistry Consultant)
 - **Theater awards** (Best Lead Actor)
 
 ### **Skills & Services**

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -599,6 +599,14 @@ def news_sitemap():
     # Sample news articles - in production, this would come from a database
     news_articles = [
         {
+            "url": "/news#f1-the-movie",
+            "title": "Cardistry Consultant on F1 The Movie",
+            "publication_date": "2025-09-01T00:00:00Z",
+            "keywords": (
+                "Jake Crossman, F1 The Movie, cardistry consultant, Joseph Kosinski"
+            ),
+        },
+        {
             "url": "/news#continue-to-win",
             "title": "Continue to Win Pilot Wraps Production",
             "publication_date": "2025-06-01T00:00:00Z",

--- a/app/seo.py
+++ b/app/seo.py
@@ -898,6 +898,13 @@ def generate_actor_profession_schema() -> Dict:
                 "datePublished": "2025",
                 "genre": ["Drama", "Sports"],
             },
+            {
+                "@type": "Movie",
+                "name": "F1 The Movie",
+                "description": "Feature film directed by Joseph Kosinski",
+                "datePublished": "2025",
+                "genre": ["Action", "Sports"],
+            },
         ],
     }
 

--- a/app/templates/about.html
+++ b/app/templates/about.html
@@ -10,7 +10,7 @@
             </div>
               <div class="bio-text">
                 <h1>Jacob "Jake" Crossman</h1>
-                <p>Jacob "Jake" Crossman is an actor and digital creator splitting time between Los Angeles and his quiet state of Virginia. A natural athlete with strong comedic instincts, Jake first made his mark on ESPN+'s sports-comedy series <em>FUSE</em> and most recently was featured in the indie pilot <em>Continue to Win</em> directed by Lester Speight.</p>
+                <p>Jacob "Jake" Crossman is an actor and digital creator splitting time between Los Angeles and his quiet state of Virginia. A natural athlete with strong comedic instincts, Jake first made his mark on ESPN+'s sports-comedy series <em>FUSE</em> and most recently was featured in the indie pilot <em>Continue to Win</em> directed by Lester Speight. He also consulted on the feature film <em>F1 The Movie</em> directed by Joseph Kosinski, lending his cardistry expertise on location in Northamptonshire, England.</p>
                 
                 <p>Trained in classical theatre and featured as Chaucer in <em>The Canturbury Tales</em> and Fagin in <em>Oliver Twist</em> at Erie's Theater, he combines physicality, improvisation chops, and a magnetic presence to bring characters vividly to life. Off-camera, he leverages over 1 million TikTok followers to craft brand-driven health and wellness content with 250 million+ views.</p>
                 
@@ -105,6 +105,7 @@
                     <li>Teleprompter Proficiency</li>
                     <li>Voice-Over Narration</li>
                     <li>Stage Combat (Basic)</li>
+                    <li>Cardistry</li>
                     <li>Digital Content Creation</li>
                     <li>Social Media Strategy</li>
                 </ul>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -82,6 +82,15 @@
                     {{ smart_image('continue-to-win-highlight', 'Continue to Win Independent Pilot') }}
                 </div>
             </div>
+            <div class="highlight-card">
+                <div class="highlight-icon">
+                    <i class="fas fa-flag-checkered"></i>
+                </div>
+                <h3 class="highlight-title">F1 The Movie<br>Consultant</h3>
+                <p class="highlight-desc">"F1 The Movie" (2025) · Cardistry Consultant</p>                <div class="highlight-image">
+                    {{ smart_image('headshot-1', 'F1 The Movie Cardistry Consultant') }}
+                </div>
+            </div>
         </div>
     </div>
 </section>

--- a/app/templates/news.html
+++ b/app/templates/news.html
@@ -14,6 +14,17 @@
 <section class="section">
     <div class="container">
         <div class="news-grid">
+            <!-- Feature Film Consulting -->
+            <article class="news-item" id="f1-the-movie">
+                <div class="news-date">September 2025</div>
+                <h3 class="news-title">Cardistry Consultant on F1 The Movie</h3>
+                <div class="news-content">
+                    <p>Thrilled to join director Joseph Kosinski on the high-octane feature <em>F1 The Movie</em> as a cardistry consultant. Filming in Northamptonshire, England has been an incredible experience, blending sleight of hand with big-screen storytelling.</p>
+                    <p><strong>Role:</strong> Cardistry Consultant<br>
+                    <strong>Location:</strong> Northamptonshire, England, UK<br>
+                    <strong>Status:</strong> Production</p>
+                </div>
+            </article>
             <!-- Recent Project -->
             <article class="news-item">
                 <div class="news-date">June 2025</div>

--- a/app/templates/resume.html
+++ b/app/templates/resume.html
@@ -89,12 +89,25 @@
                 <div class="highlight-item">
                     <strong>Independent Film:</strong> Lead antagonist role in "Continue to Win" (2025) directed by Lester Speight
                 </div>
+                <div class="highlight-item">
+                    <strong>Feature Film:</strong> Cardistry Consultant for "F1 The Movie" (2025) directed by Joseph Kosinski
+                </div>
             </div>
         </div>
 
         <div class="resume-section">
             <h3><i class="fas fa-video"></i> On-Screen & Sketch Credits</h3>
             <div class="credits-list">
+                <div class="credit-item">
+                    <div class="credit-header">
+                        <span class="credit-title">F1 The Movie</span>
+                        <span class="credit-year">2025</span>
+                    </div>
+                    <div class="credit-details">
+                        <span class="credit-role">Cardistry Consultant</span>
+                        <span class="credit-type">Feature Film • Dir. Joseph Kosinski • Northamptonshire, England, UK</span>
+                    </div>
+                </div>
                 <div class="credit-item">
                     <div class="credit-header">
                         <span class="credit-title">Continue to Win</span>
@@ -216,7 +229,7 @@
                 </div>
                 <div class="skill-category">
                     <h4>Performance</h4>
-                    <p>Stage Combat, Voiceover, Sports Play-by-Play, Teleprompter, Improv</p>
+                    <p>Stage Combat, Voiceover, Sports Play-by-Play, Teleprompter, Improv, Cardistry</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- include new film credit on resume
- mention movie credit in About page bio and skills
- feature the film in news updates and homepage highlights
- expand news sitemap and person schema for the new credit
- document credit in SEO reports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68544bc1e8b88327bf4291d97aa349b7