### PR TITLE
Compute summary savings in image optimization

### DIFF
--- a/image_optimization.py
+++ b/image_optimization.py
@@ -326,6 +326,8 @@ Run `python image_optimization.py` to update when you add new images.
         total_original_size = 0
         total_webp_size = 0
         total_optimized_size = 0
+        total_webp_savings = 0
+        total_opt_savings = 0
         webp_count = 0
         optimized_count = 0
         error_count = 0
@@ -347,6 +349,16 @@ Run `python image_optimization.py` to update when you add new images.
 
             if results["errors"]:
                 error_count += 1
+
+        # Calculate overall savings
+        if total_webp_size > 0:
+            total_webp_savings = self.calculate_savings(
+                total_original_size, total_webp_size
+            )
+        if total_optimized_size > 0:
+            total_opt_savings = self.calculate_savings(
+                total_original_size, total_optimized_size
+            )
 
         # Create usage examples
         self.create_usage_examples()
@@ -370,12 +382,12 @@ Run `python image_optimization.py` to update when you add new images.
             if total_webp_size > 0:
                 print(
                     f"WebP total: {total_webp_size:.2f} MB "
-                    "({total_webp_savings:.1f}% savings)"
+                    f"({total_webp_savings:.1f}% savings)"
                 )
             if total_optimized_size > 0:
                 print(
                     f"Optimized total: {total_optimized_size:.2f} MB "
-                    "({total_opt_savings:.1f}% savings)"
+                    f"({total_opt_savings:.1f}% savings)"
                 )
 
         print(f"\nOptimized files location: {self.optimized_dir}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,9 @@
+import sys
+from pathlib import Path
 import pytest
-from app import create_app
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from app import create_app  # noqa: E402
 
 
 @pytest.fixture

--- a/tests/test_image_optimization.py
+++ b/tests/test_image_optimization.py
@@ -1,0 +1,32 @@
+import builtins
+from pathlib import Path
+from image_optimization import ImageOptimizer
+
+
+def test_run_optimization_summary(monkeypatch, tmp_path, capsys):
+    optimizer = ImageOptimizer(base_dir=tmp_path)
+    optimizer.images_dir.mkdir(parents=True)
+    optimizer.optimized_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(optimizer, "check_dependencies", lambda: True)
+    monkeypatch.setattr(optimizer, "create_usage_examples", lambda: None)
+    monkeypatch.setattr(optimizer, "get_image_files", lambda: [Path("dummy.jpg")])
+    monkeypatch.setattr(optimizer, "get_file_size_mb", lambda path: 2)
+    monkeypatch.setattr(
+        optimizer,
+        "optimize_image",
+        lambda path: {
+            "original_size": 2,
+            "webp_created": True,
+            "original_optimized": True,
+            "webp_size": 1,
+            "optimized_size": 1.5,
+            "errors": [],
+        },
+    )
+    monkeypatch.setattr(builtins, "input", lambda: "y")
+
+    optimizer.run_optimization()
+    out = capsys.readouterr().out
+    assert "WebP total: 1.00 MB (50.0% savings)" in out
+    assert "Optimized total: 1.50 MB (25.0% savings)" in out


### PR DESCRIPTION
## Summary
- fix image summary output by calculating savings before printing
- ensure savings variables are initialised
- adjust pytest config so app package can be imported
- add tests for optimisation summary output

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685463476f988327887b1be3fb054258