### PR TITLE
Add sitemap and robots route tests

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -37,3 +37,38 @@ def test_video_encoded_traversal(client):
     """Encoded path traversal should also be blocked."""
     response = client.get("/video/..%2F..%2Fetc/passwd")
     assert response.status_code == 404
+
+
+def test_sitemap_xml(client):
+    """Ensure the main sitemap is reachable and XML is returned."""
+    response = client.get("/sitemap.xml")
+    assert response.status_code == 200
+    assert response.headers["Content-Type"].startswith("application/xml")
+
+
+def test_news_sitemap_xml(client):
+    """Ensure the news sitemap endpoint returns XML."""
+    response = client.get("/news-sitemap.xml")
+    assert response.status_code == 200
+    assert response.headers["Content-Type"].startswith("application/xml")
+
+
+def test_image_sitemap_xml(client):
+    """Ensure the image sitemap endpoint returns XML."""
+    response = client.get("/image-sitemap.xml")
+    assert response.status_code == 200
+    assert response.headers["Content-Type"].startswith("application/xml")
+
+
+def test_video_sitemap_xml(client):
+    """Ensure the video sitemap endpoint returns XML."""
+    response = client.get("/video-sitemap.xml")
+    assert response.status_code == 200
+    assert response.headers["Content-Type"].startswith("application/xml")
+
+
+def test_robots_txt(client):
+    """Ensure robots.txt is served with plain text content."""
+    response = client.get("/robots.txt")
+    assert response.status_code == 200
+    assert response.headers["Content-Type"].startswith("text/plain")


### PR DESCRIPTION
## Summary
- expand route tests to cover sitemap and robots endpoints

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68559ec6c82c8327b9ea5652c3bd7e80