### PR TITLE
Add custom 404 handler and test

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-from flask import Flask
+from flask import Flask, render_template
 from flask_wtf import CSRFProtect
 import os
 from dotenv import load_dotenv
@@ -43,5 +43,10 @@ def create_app(config_name="default"):
     from app.main import bp as main_bp
 
     app.register_blueprint(main_bp)
+
+    @app.errorhandler(404)
+    def page_not_found(error):
+        """Render custom 404 page."""
+        return render_template("404.html"), 404
 
     return app

--- a/app/templates/404.html
+++ b/app/templates/404.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="error-page">
+    <div class="container" style="text-align: center; padding: 2rem;">
+        <h1>Page Not Found</h1>
+        <p>Sorry, the page you requested could not be found.</p>
+    </div>
+</section>
+{% endblock %}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -37,3 +37,10 @@ def test_video_encoded_traversal(client):
     """Encoded path traversal should also be blocked."""
     response = client.get("/video/..%2F..%2Fetc/passwd")
     assert response.status_code == 404
+
+
+def test_unknown_page(client):
+    """Requesting an unknown page should return custom 404 template."""
+    response = client.get("/does-not-exist")
+    assert response.status_code == 404
+    assert b"Page Not Found" in response.data


### PR DESCRIPTION
## Summary
- handle 404 errors with a dedicated template
- create `404.html` page for user-friendly message
- test that unknown pages return 404 status and template content

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68559ec342e88327bb15341632d56e7e