### PR TITLE
Fix email body formatting and add tests

### DIFF
--- a/app/email_utils.py
+++ b/app/email_utils.py
@@ -54,6 +54,12 @@ def create_email_body(form_data):
     message = form_data.get("message", "Not provided")
     resume_attach = form_data.get("resume_attach", False)
 
+    professional_materials = (
+        '<p><strong>Professional Materials Package Requested:</strong> "Yes"</p>'
+        if resume_attach
+        else ""
+    )
+
     html_body = f"""
     <h2>New Contact Form Submission</h2>
     <p><strong>Name:</strong> {name}</p>
@@ -62,8 +68,7 @@ def create_email_body(form_data):
     <p><strong>Role/Opportunity:</strong> {role}</p>
     <p><strong>Timeline:</strong> {timeline}</p>
     <p><strong>Message:</strong> {message}</p>
-    {f'<p><strong>Professional Materials Package Requested:</strong> '
-     f'"Yes</p>' if resume_attach else ''}
+    {professional_materials}
     """
 
     return html_body

--- a/tests/test_email_utils.py
+++ b/tests/test_email_utils.py
@@ -1,0 +1,31 @@
+import pytest
+from app.email_utils import create_email_body
+
+
+def test_create_email_body_with_resume():
+    data = {
+        "name": "Tester",
+        "email": "tester@example.com",
+        "production": "Prod",
+        "role": "Actor",
+        "timeline": "Soon",
+        "message": "Hello",
+        "resume_attach": True,
+    }
+    body = create_email_body(data)
+    expected = '<p><strong>Professional Materials Package Requested:</strong> "Yes"</p>'
+    assert expected in body
+
+
+def test_create_email_body_without_resume():
+    data = {
+        "name": "Tester",
+        "email": "tester@example.com",
+        "production": "Prod",
+        "role": "Actor",
+        "timeline": "Soon",
+        "message": "Hello",
+        "resume_attach": False,
+    }
+    body = create_email_body(data)
+    assert 'Professional Materials Package Requested' not in body


### PR DESCRIPTION
## Summary
- fix quote balancing in `create_email_body`
- test `create_email_body` for resume requests

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68559ebbba9c832787f4fb2de0380c8c