### PR TITLE
Add config classes for Flask app

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,24 @@ A Flask-based portfolio website for showcasing theatrical work and performances.
    python3.12 app.py
    ```
 
+## Configuration
+
+`create_app` accepts a configuration profile name:
+
+- `development`
+- `testing`
+- `production`
+
+Call the factory with the desired profile:
+
+```python
+from app import create_app
+
+app = create_app("production")
+```
+
+Without an argument, the development configuration is used.
+
 ## Dependencies
 
 The project relies on the following Python packages for HTTP requests and HTML parsing:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,41 +3,75 @@ from flask_wtf import CSRFProtect
 import os
 from dotenv import load_dotenv
 
+# Load environment variables so configuration classes can access them
+load_dotenv()
+
 csrf = CSRFProtect()
 
 
-def create_app(config_name="default"):
-    """Application factory pattern."""
-    # Load environment variables from .env file
-    load_dotenv()
+class BaseConfig:
+    """Base configuration with common settings."""
 
-    app = Flask(__name__)  # Load configuration from environment variables
-    app.config["SECRET_KEY"] = os.getenv("SECRET_KEY", "fallback-secret-key")
-    csrf.init_app(app)
-    app.config["SEND_FILE_MAX_AGE_DEFAULT"] = 0
-    app.config["MAX_CONTENT_LENGTH"] = 100 * 1024 * 1024
+    SECRET_KEY = os.getenv("SECRET_KEY", "fallback-secret-key")
+    SEND_FILE_MAX_AGE_DEFAULT = 0
+    MAX_CONTENT_LENGTH = 100 * 1024 * 1024
 
     # Email Configuration
-    app.config["SMTP_SERVER"] = os.getenv("SMTP_SERVER")
-    app.config["SMTP_PORT"] = int(os.getenv("SMTP_PORT", 587))
-    app.config["MAIL_USERNAME"] = os.getenv("MAIL_USERNAME")
-    app.config["MAIL_PASSWORD"] = os.getenv("MAIL_PASSWORD")
-    app.config["EMAIL_FROM"] = os.getenv("EMAIL_FROM")
-    app.config["EMAIL_TO"] = os.getenv("EMAIL_TO")
+    SMTP_SERVER = os.getenv("SMTP_SERVER")
+    SMTP_PORT = int(os.getenv("SMTP_PORT", 587))
+    MAIL_USERNAME = os.getenv("MAIL_USERNAME")
+    MAIL_PASSWORD = os.getenv("MAIL_PASSWORD")
+    EMAIL_FROM = os.getenv("EMAIL_FROM")
+    EMAIL_TO = os.getenv("EMAIL_TO")
 
     # Analytics Configuration
-    app.config["GOOGLE_ANALYTICS_ID"] = os.getenv("GOOGLE_ANALYTICS_ID")
-    app.config["GOOGLE_TAG_MANAGER_ID"] = os.getenv("GOOGLE_TAG_MANAGER_ID")
-    app.config["CLARITY_PROJECT_ID"] = os.getenv("CLARITY_PROJECT_ID")
-    app.config["FACEBOOK_PIXEL_ID"] = os.getenv("FACEBOOK_PIXEL_ID")
+    GOOGLE_ANALYTICS_ID = os.getenv("GOOGLE_ANALYTICS_ID")
+    GOOGLE_TAG_MANAGER_ID = os.getenv("GOOGLE_TAG_MANAGER_ID")
+    CLARITY_PROJECT_ID = os.getenv("CLARITY_PROJECT_ID")
+    FACEBOOK_PIXEL_ID = os.getenv("FACEBOOK_PIXEL_ID")
 
     # Search Engine Verification
-    app.config["GOOGLE_SEARCH_CONSOLE_VERIFICATION"] = os.getenv(
-        "GOOGLE_SEARCH_CONSOLE_VERIFICATION"
-    )
-    app.config["BING_VERIFICATION"] = os.getenv("BING_VERIFICATION")
-    app.config["YANDEX_VERIFICATION"] = os.getenv("YANDEX_VERIFICATION")
-    app.config["PINTEREST_VERIFICATION"] = os.getenv("PINTEREST_VERIFICATION")
+    GOOGLE_SEARCH_CONSOLE_VERIFICATION = os.getenv("GOOGLE_SEARCH_CONSOLE_VERIFICATION")
+    BING_VERIFICATION = os.getenv("BING_VERIFICATION")
+    YANDEX_VERIFICATION = os.getenv("YANDEX_VERIFICATION")
+    PINTEREST_VERIFICATION = os.getenv("PINTEREST_VERIFICATION")
+
+
+class DevelopmentConfig(BaseConfig):
+    """Configuration for local development."""
+
+    DEBUG = True
+
+
+class TestingConfig(BaseConfig):
+    """Configuration used during tests."""
+
+    TESTING = True
+
+
+class ProductionConfig(BaseConfig):
+    """Configuration for deployed environments."""
+
+    DEBUG = False
+
+
+def create_app(config_name="development"):
+    """Application factory pattern."""
+    load_dotenv()
+
+    app = Flask(__name__)
+
+    # Map config names to classes
+    config_map = {
+        "development": DevelopmentConfig,
+        "testing": TestingConfig,
+        "production": ProductionConfig,
+        "default": DevelopmentConfig,
+    }
+
+    config_class = config_map.get(config_name, DevelopmentConfig)
+    app.config.from_object(config_class)
+    csrf.init_app(app)
 
     # Register blueprints
     from app.main import bp as main_bp


### PR DESCRIPTION
## Summary
- define `DevelopmentConfig`, `TestingConfig`, and `ProductionConfig`
- load the correct config class in `create_app`
- document how to choose a configuration profile

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855ad42acd48327ac7e395d585ac548