### PR TITLE
Add JSON output option to seo_tester

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ The project relies on the following Python packages for HTTP requests and HTML p
 - Lint code: `flake8 .`
 - Install pre-commit hooks: `pre-commit install`
 
+## SEO Testing
+
+Run the automated SEO tester against a running instance:
+
+```bash
+python seo_tester.py --url http://localhost:5000 --json-output results.json
+```
+
+This writes the raw results to `results.json`. Use `--page PATH` to test a
+single page.
+
 ## Docker
 
 Build and run with Docker:

--- a/seo_tester.py
+++ b/seo_tester.py
@@ -347,6 +347,11 @@ def main():
         help="Base URL to test (default: http://localhost:5000)",
     )
     parser.add_argument("--page", help="Test specific page only")
+    parser.add_argument(
+        "--json-output",
+        metavar="FILE",
+        help="Write raw results to FILE in JSON format",
+    )
 
     args = parser.parse_args()
 
@@ -355,11 +360,20 @@ def main():
     if args.page:
         print(f"Testing single page: {args.page}")
         success = tester.test_page(args.page)
-        tester.print_results()
-        sys.exit(0 if success else 1)
     else:
         success = tester.run_all_tests()
-        sys.exit(0 if success else 1)
+
+    tester.print_results()
+
+    if args.json_output:
+        try:
+            with open(args.json_output, "w") as f:
+                json.dump(tester.results, f, indent=2)
+            print(f"Results written to {args.json_output}")
+        except OSError as e:
+            print(f"Failed to write results file: {e}", file=sys.stderr)
+
+    sys.exit(0 if success else 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend `seo_tester.py` CLI with `--json-output FILE`
- document the SEO tester usage and new flag in README

## Testing
- `black seo_tester.py`
- `flake8 seo_tester.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855b0d7fe848327b3f4eaefde18127f