### PR TITLE
Add docker-compose with nginx reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,22 @@ docker build -t actor-portfolio .
 docker run -p 5000:5000 actor-portfolio
 ```
 
+### Docker Compose
+
+For a production-style deployment using Nginx as a reverse proxy, you can use
+`docker-compose`:
+
+```bash
+# Copy environment variables
+cp .env.example .env
+
+# Build and start the services
+docker-compose up --build
+```
+
+The application will be available on port `80` and static files are served
+directly by Nginx.
+
 ## Citation
 
 To cite this project, please use the metadata provided in [CITATION.cff](CITATION.cff).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3.9"
+
+services:
+  web:
+    build: .
+    env_file: .env
+    command: gunicorn --bind 0.0.0.0:5000 "app:create_app('production')"
+    expose:
+      - "5000"
+
+  nginx:
+    image: nginx:stable-alpine
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./app/static:/app/static:ro
+    depends_on:
+      - web

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,18 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    location /static/ {
+        alias /app/static/;
+        expires 30d;
+        add_header Cache-Control "public";
+    }
+
+    location / {
+        proxy_pass http://web:5000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
## Summary
- add minimal docker-compose setup
- configure nginx to proxy to the Flask app
- document docker-compose usage in README

## Testing
- `pytest`
- `flake8 .`

------
https://chatgpt.com/codex/tasks/task_e_6855b0d933788327abd2ef9c2f55876e